### PR TITLE
Fix/cliptool settings lost

### DIFF
--- a/src/client/components/Settings.tsx
+++ b/src/client/components/Settings.tsx
@@ -44,6 +44,17 @@ export const SettingsPage = () => {
         socket.emit(IO.SET_GENERICS, reduxState.settings[0].generics)
     }
 
+    const handleRestart = () => {
+        if (
+            window.confirm(
+                'Restarting server will stop all outputs, are you sure?'
+            )
+        ) {
+            console.log('Restarting server...')
+            socket.emit(IO.RESTART_SERVER)
+        }
+    }
+
     return (
         <div className="Settings-body">
             <p className="Settings-header">SETTINGS :</p>
@@ -127,12 +138,16 @@ export const SettingsPage = () => {
                 >
                     UPDATE CLIPTOOL SETTINGS
                 </button>
-                <button
-                    className="save-button"
-                    onClick={() => socket.emit(IO.RESTART_SERVER)}
-                >
-                    RESTART CLIPTOOL
-                </button>
+                {!specificChannel ? (
+                    <button
+                        className="save-button"
+                        onClick={() => handleRestart()}
+                    >
+                        RESTART CLIPTOOL
+                    </button>
+                ) : (
+                    <React.Fragment />
+                )}
                 <button
                     className="save-button"
                     onClick={() => handleSettingsPage()}
@@ -152,17 +167,20 @@ const RenderOutputSettings = () => {
     }
     const handleLoop = (event) => {
         let generics = { ...reduxState.settings[0].generics }
-        generics.startupLoopState[parseInt(event.target.name)] = event.target.checked
+        generics.startupLoopState[parseInt(event.target.name)] =
+            event.target.checked
         reduxStore.dispatch(setGenerics(generics))
     }
     const handleMix = (event) => {
         let generics = { ...reduxState.settings[0].generics }
-        generics.startupMixState[parseInt(event.target.name)] = event.target.checked
+        generics.startupMixState[parseInt(event.target.name)] =
+            event.target.checked
         reduxStore.dispatch(setGenerics(generics))
     }
     const handleManual = (event) => {
         let generics = { ...reduxState.settings[0].generics }
-        generics.startupManualstartState[parseInt(event.target.name)] = event.target.checked
+        generics.startupManualstartState[parseInt(event.target.name)] =
+            event.target.checked
         reduxStore.dispatch(setGenerics(generics))
     }
 
@@ -242,7 +260,11 @@ const RenderOutputSettings = () => {
                     <input
                         name={String(index)}
                         type="checkbox"
-                        checked={reduxState.settings[0].generics.startupLoopState?.[index]}
+                        checked={
+                            reduxState.settings[0].generics.startupLoopState?.[
+                                index
+                            ]
+                        }
                         onChange={handleLoop}
                     />
                 </label>
@@ -252,7 +274,11 @@ const RenderOutputSettings = () => {
                     <input
                         name={String(index)}
                         type="checkbox"
-                        checked={reduxState.settings[0].generics.startupMixState?.[index]}
+                        checked={
+                            reduxState.settings[0].generics.startupMixState?.[
+                                index
+                            ]
+                        }
                         onChange={handleMix}
                     />
                 </label>
@@ -262,7 +288,10 @@ const RenderOutputSettings = () => {
                     <input
                         name={String(index)}
                         type="checkbox"
-                        checked={reduxState.settings[0].generics.startupManualstartState?.[index]}
+                        checked={
+                            reduxState.settings[0].generics
+                                .startupManualstartState?.[index]
+                        }
                         onChange={handleManual}
                     />
                 </label>

--- a/src/model/reducers/settingsReducer.ts
+++ b/src/model/reducers/settingsReducer.ts
@@ -40,57 +40,59 @@ export interface IGenericSettings {
     startupManualstartState: boolean[]
 }
 
-const defaultSettingsReducerState: ISettings[] = [
-    {
-        ccgConfig: {
-            channels: [],
-            path: '',
+export const defaultSettingsReducerState = (): ISettings[] => {
+    return [
+        {
+            ccgConfig: {
+                channels: [],
+                path: '',
+            },
+            tabData: [],
+            generics: {
+                transistionTime: 16,
+                ccgIp: '0.0.0.0',
+                ccgAmcpPort: 5250,
+                ccgOscPort: 5253,
+                ccgDefaultLayer: 10,
+                outputLabels: ['', '', '', '', '', '', '', ''],
+                outputFolders: ['', '', '', '', '', '', '', ''],
+                scale: [false, false, false, false, false, false, false, false],
+                scaleX: [1920, 1920, 1920, 1920, 1920, 1920, 1920, 1920],
+                scaleY: [1080, 1080, 1080, 1080, 1080, 1080, 1080, 1080],
+                startupLoopState: [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                ],
+                startupMixState: [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                ],
+                startupManualstartState: [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                ],
+            },
         },
-        tabData: [],
-        generics: {
-            transistionTime: 16,
-            ccgIp: '0.0.0.0',
-            ccgAmcpPort: 5250,
-            ccgOscPort: 5253,
-            ccgDefaultLayer: 10,
-            outputLabels: ['', '', '', '', '', '', '', ''],
-            outputFolders: ['', '', '', '', '', '', '', ''],
-            scale: [false, false, false, false, false, false, false, false],
-            scaleX: [1920, 1920, 1920, 1920, 1920, 1920, 1920, 1920],
-            scaleY: [1080, 1080, 1080, 1080, 1080, 1080, 1080, 1080],
-            startupLoopState: [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-            ],
-            startupMixState: [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-            ],
-            startupManualstartState: [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-            ],
-        },
-    },
-]
+    ]
+}
 
 function updateChannelConfigWithVideoFormat(
     channelConfig: ICcgConfigChannel
@@ -102,7 +104,7 @@ function updateChannelConfigWithVideoFormat(
 }
 
 export const settings = (
-    state: ISettings[] = defaultSettingsReducerState,
+    state: ISettings[] = defaultSettingsReducerState(),
     action
 ) => {
     let nextState = { ...state }

--- a/src/server/utils/SettingsStorage.ts
+++ b/src/server/utils/SettingsStorage.ts
@@ -19,7 +19,7 @@ export const loadSettings = () => {
 }
 
 export const saveSettings = () => {
-    let stringifiedSettings = JSON.stringify(reduxState.settings[0].generics)
+    const stringifiedSettings = JSON.stringify(reduxState.settings[0].generics)
     if (!fs.existsSync('storage')) {
         fs.mkdirSync('storage')
     }

--- a/src/server/utils/SettingsStorage.ts
+++ b/src/server/utils/SettingsStorage.ts
@@ -1,4 +1,5 @@
 import { setGenerics } from '../../model/reducers/settingsAction'
+import { defaultSettingsReducerState } from '../../model/reducers/settingsReducer'
 import { reduxState, reduxStore } from '../../model/reducers/store'
 import { logger } from './logger'
 
@@ -18,17 +19,23 @@ export const loadSettings = () => {
 }
 
 export const saveSettings = () => {
-    var json = JSON.stringify(reduxState.settings[0].generics)
+    let stringifiedSettings = JSON.stringify(reduxState.settings[0].generics)
     if (!fs.existsSync('storage')) {
         fs.mkdirSync('storage')
     }
-
-    fs.writeFile(
-        path.resolve('storage', 'settings.json'),
-        json,
-        'utf8',
-        (error) => {
-            console.log(error)
-        }
-    )
+    if (
+        stringifiedSettings !==
+        JSON.stringify(defaultSettingsReducerState()[0].generics)
+    ) {
+        fs.writeFile(
+            path.resolve('storage', 'settings.json'),
+            stringifiedSettings,
+            'utf8',
+            (error) => {
+                console.log(error)
+            }
+        )
+    } else {
+        console.log('Settings not saved, using defaults')
+    }
 }


### PR DESCRIPTION
Fix: Prevent initial settings to be written to file. (could happen if storing before the settings had been reloaded)
Feat: Confirm a ClipTool restart (using window.confirm)
Feat: Hide restart when a client is on a single output. This would cause all outputs to stop, also the ones that the client didn't know about.

