### PR TITLE
fix: load of thumnails resultet in overload response from CasparCG

### DIFF
--- a/src/server/services/amcp-thumbnails-service.ts
+++ b/src/server/services/amcp-thumbnails-service.ts
@@ -151,14 +151,17 @@ export class AmcpThumbnailsService {
         }
     }
 
-    private loadThumbnails(
+    private async loadThumbnails(
         retrievedThumbnails: ThumbnailFile[]
     ): Promise<ThumbnailFile[]> {
-        return Promise.all(
-            retrievedThumbnails.map((thumbnailFile) =>
-                this.loadThumbnailImage(thumbnailFile)
-            )
-        )
+        const results: ThumbnailFile[] = []
+
+        for (const thumbnailFile of retrievedThumbnails) {
+            const result = await this.loadThumbnailImage(thumbnailFile)
+            results.push(result)
+        }
+
+        return results
     }
 
     private async loadThumbnailImage(


### PR DESCRIPTION
I did this fix on a wrong branch name (sorry)

fix: load of thumnails resultet in overload response from CasparCG and a following crash. 
for... of...  -> await loop has been implemented instead.
